### PR TITLE
Add missing COTA cortex page

### DIFF
--- a/docs/before-summer/COTA-cortex.html
+++ b/docs/before-summer/COTA-cortex.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<meta name="generator" content="pandoc" />
+<meta http-equiv="X-UA-Compatible" content="IE=EDGE" />
+<meta name="author" content="Marcus Chandra" />
+<meta name="date" content="2025-07-01" />
+<title>Prior to summer: Cortex COTA SNP Mediation</title>
+<link href="../site_libs/bootstrap-3.3.5/css/bootstrap.min.css" rel="stylesheet" />
+<link rel="stylesheet" href="../style.css" />
+<script src="../site_libs/jquery-3.6.0/jquery-3.6.0.min.js"></script>
+<script src="../site_libs/bootstrap-3.3.5/js/bootstrap.min.js"></script>
+</head>
+<body>
+<div class="container">
+<h1>Prior to summer: Cortex COTA SNP Mediation</h1>
+<p>In this analysis, I applied the Gene-Gene case COTA mediation framework to a GTEx brain tissue dataset. We use WES burden test results from the UK Biobank (UKBB) for our Gene 2 candidates. We use an eQTL matrix from GTEx to detect trans effects from peripheral Gene 1 to Gene 2.</p>
+<h2>Key steps</h2>
+<ul>
+<li>Prepare UKBB wes p-values</li>
+<li>Load and clean the trans eQTL matrix.</li>
+<li>Run COTA using <code>med_gene()</code> function and <code>calc_pair.gene()</code> to match gene pairs for visualization.</li>
+<li>Visualize the network of significant mediation pairs.</li>
+</ul>
+<p>Load required R libraries for COTA analysis.</p>
+<h2>Code chunks</h2>
+<h3>5.1. Load UKBB WES p-values</h3>
+<p>Read WES p-values from UKBB and format phenotype names.</p>
+<h3>5.2. Load eQTL matrix</h3>
+<p>Load eQTL matrix, set threshold, and prepare candidate genes list.</p>
+<h3>5.3. Run COTA mediation</h3>
+<p>Run COTA mediation analysis.</p>
+<h3>5.4. Visualize mediation pairs</h3>
+<p>Visualize significant mediation pairs.</p>
+<h2>Session info</h2>
+<p>Session information for reproducibility.</p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new HTML page for the COTA cortex analysis under `docs/before-summer`

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_687c1a29121483208203d99f99b93451